### PR TITLE
fix usage of LineNumberNode constructor on 1.5

### DIFF
--- a/src/AbstractPattern.jl
+++ b/src/AbstractPattern.jl
@@ -34,7 +34,7 @@ end
 
 function spec_gen(branches :: Vector)
     cores = Branch[]
-    ln = LineNumberNode(1, "<unknown>")
+    ln = LineNumberNode(1, Symbol("<unknown>"))
     for branch in branches
         branch isa LineNumberNode && begin
             ln = branch


### PR DESCRIPTION
This now requires the second argument to be a symbol.